### PR TITLE
More aggressive retry handling.

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -15,6 +15,7 @@ jobs:
         ruby:
           - 2.6
           - 2.7
+          - 3.0
         
         experimental: [false]
         env: [""]
@@ -23,7 +24,7 @@ jobs:
           - os: ubuntu
             ruby: head
             experimental: true
-
+    
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/lib/aerospike/aerospike_exception.rb
+++ b/lib/aerospike/aerospike_exception.rb
@@ -39,7 +39,7 @@ module Aerospike
         @failed_nodes = failed_nodes
         @failed_connections = failed_connections
 
-        super(ResultCode::TIMEOUT)
+        super(ResultCode::TIMEOUT, "Timeout after #{iterations} attempts!")
       end
     end
 

--- a/lib/aerospike/aerospike_exception.rb
+++ b/lib/aerospike/aerospike_exception.rb
@@ -31,12 +31,26 @@ module Aerospike
 
       def retryable?
         case @result_code
-        when ResultCode::ENTERPRISE_ONLY
-          false
-        when ResultCode::FILTERED_OUT
-          false
-        else
+        when ResultCode::COMMAND_REJECTED
           true
+        when ResultCode::INVALID_NODE_ERROR
+          true
+        when ResultCode::SERVER_ERROR
+          true
+        when ResultCode::SERVER_MEM_ERROR
+          true
+        when ResultCode::TIMEOUT
+          true
+        when ResultCode::KEY_BUSY
+          true
+        when ResultCode::SERVER_NOT_AVAILABLE
+          true
+        when ResultCode::DEVICE_OVERLOAD
+          true
+        when ResultCode::QUERY_NET_IO
+          true
+        else
+          false
         end
       end
     end
@@ -51,6 +65,10 @@ module Aerospike
         @failed_connections = failed_connections
 
         super(ResultCode::TIMEOUT, "Timeout after #{iterations} attempts!")
+      end
+
+      def retryable?
+        true
       end
     end
 
@@ -76,6 +94,10 @@ module Aerospike
       def initialize(msg=nil)
         super(ResultCode::SERVER_NOT_AVAILABLE, msg)
       end
+
+      def retryable?
+        true
+      end
     end
 
     class InvalidNode < Aerospike
@@ -88,19 +110,11 @@ module Aerospike
       def initialize(msg=nil)
         super(ResultCode::SCAN_TERMINATED, msg)
       end
-
-      def retryable?
-        false
-      end
     end
 
     class QueryTerminated < Aerospike
       def initialize(msg=nil)
         super(ResultCode::QUERY_TERMINATED, msg)
-      end
-
-      def retryable?
-        false
       end
     end
 
@@ -113,10 +127,6 @@ module Aerospike
     class InvalidNamespace < Aerospike
       def initialize(msg=nil)
         super(ResultCode::INVALID_NAMESPACE, msg)
-      end
-
-      def retryable?
-        false
       end
     end
   end

--- a/lib/aerospike/aerospike_exception.rb
+++ b/lib/aerospike/aerospike_exception.rb
@@ -28,6 +28,17 @@ module Aerospike
         message ||= ResultCode.message(result_code)
         super(message)
       end
+
+      def retryable?
+        case @result_code
+        when ResultCode::ENTERPRISE_ONLY
+          false
+        when ResultCode::FILTERED_OUT
+          false
+        else
+          true
+        end
+      end
     end
 
     class Timeout < Aerospike
@@ -77,11 +88,19 @@ module Aerospike
       def initialize(msg=nil)
         super(ResultCode::SCAN_TERMINATED, msg)
       end
+
+      def retryable?
+        false
+      end
     end
 
     class QueryTerminated < Aerospike
       def initialize(msg=nil)
         super(ResultCode::QUERY_TERMINATED, msg)
+      end
+
+      def retryable?
+        false
       end
     end
 
@@ -94,6 +113,10 @@ module Aerospike
     class InvalidNamespace < Aerospike
       def initialize(msg=nil)
         super(ResultCode::INVALID_NAMESPACE, msg)
+      end
+
+      def retryable?
+        false
       end
     end
   end

--- a/lib/aerospike/command/command.rb
+++ b/lib/aerospike/command/command.rb
@@ -429,17 +429,20 @@ module Aerospike
 
       # set timeout outside the loop
       limit = Time.now + @policy.timeout
+      retries = @policy.max_retries
 
-      # Execute command until successful, timed out or maximum iterations have been reached.
-      while true
-        # too many retries
+      # Execute command until successful, timed out or maximum iterations have been reached:
+      while iterations <= retries
+        # Sleep before trying again, after the first iteration:
+        if iterations > 0 && @policy.sleep_between_retries > 0
+          # Use a back-off according to the number of iterations:
+          sleep(@policy.sleep_between_retries * iterations)
+        end
+
+        # Next iteration:
         iterations += 1
-        break if (@policy.max_retries > 0) && (iterations > @policy.max_retries+1)
 
-        # Sleep before trying again, after the first iteration
-        sleep(@policy.sleep_between_retries) if iterations > 1 && @policy.sleep_between_retries > 0
-
-        # check for command timeout
+        # Check for command timeout:
         break if @policy.timeout > 0 && Time.now > limit
 
         begin
@@ -457,7 +460,7 @@ module Aerospike
           next
         end
 
-        # Draw a buffer from buffer pool, and make sure it will be put back
+        # Draw a buffer from buffer pool, and make sure it will be put back:
         begin
           @data_buffer = Buffer.get
 
@@ -494,19 +497,11 @@ module Aerospike
           # Parse results.
           begin
             parse_result
-          rescue Aerospike::Exceptions::Aerospike => e
-            case e
-            # do not log the following exceptions
-            when Aerospike::Exceptions::ScanTerminated
-            when Aerospike::Exceptions::QueryTerminated
-            else
-              Aerospike.logger.error(e)
-            end
-
             # close the connection
             # cancelling/closing the batch/multi commands will return an error, which will
             # close the connection to throw away its data and signal the server about the
             # situation. We will not put back the connection in the buffer.
+          rescue Aerospike::Exceptions::ScanTerminated, Aerospike::Exceptions::QueryTerminated
             @conn.close if @conn
             raise e
           rescue
@@ -524,6 +519,7 @@ module Aerospike
           return
         ensure
           Buffer.put(@data_buffer)
+          @data_buffer = nil
         end
 
       end # while

--- a/lib/aerospike/command/command.rb
+++ b/lib/aerospike/command/command.rb
@@ -497,13 +497,19 @@ module Aerospike
           # Parse results.
           begin
             parse_result
+          rescue Aerospike::Exceptions::Aerospike => exception
             # close the connection
             # cancelling/closing the batch/multi commands will return an error, which will
             # close the connection to throw away its data and signal the server about the
             # situation. We will not put back the connection in the buffer.
-          rescue Aerospike::Exceptions::ScanTerminated, Aerospike::Exceptions::QueryTerminated
             @conn.close if @conn
-            raise e
+
+            # Some exceptions are non-fatal and retrying may succeed:
+            if exception.retryable?
+              next
+            else
+              raise
+            end
           rescue
             @conn.close if @conn
             next

--- a/lib/aerospike/policy/policy.rb
+++ b/lib/aerospike/policy/policy.rb
@@ -109,7 +109,7 @@ module Aerospike
       # A retry is attempted when there is a network error other than timeout.
       # If max_retries is exceeded, the abort will occur even if the timeout
       # has not yet been exceeded.
-      @max_retries = opt[:max_retries] || 2
+      @max_retries = opt[:max_retries] || 3
 
       # Duration to sleep between retries if a transaction fails and the
       # timeout was not exceeded. Enter zero to skip sleep.

--- a/lib/aerospike/result_code.rb
+++ b/lib/aerospike/result_code.rb
@@ -98,7 +98,7 @@ module Aerospike
     # Bin not found on update-only operation.
     BIN_NOT_FOUND = 17
 
-    # Specified bin name does not exist in record.
+    # Device not keeping up with writes.
     DEVICE_OVERLOAD = 18
 
     # Key type mismatch.

--- a/spec/aerospike/cluster_spec.rb
+++ b/spec/aerospike/cluster_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Aerospike::Cluster do
   let(:policy) { spy }
   let(:hosts) { [] }
 
+  after do
+    instance.close
+  end
+
   describe '#refresh_nodes' do
     subject(:refresh_nodes) { instance.refresh_nodes }
     let!(:peers) { ::Aerospike::Peers.new }

--- a/spec/aerospike/policy/policy_spec.rb
+++ b/spec/aerospike/policy/policy_spec.rb
@@ -27,7 +27,7 @@ describe Aerospike::Policy do
       expect(policy.class).to eq described_class
       expect(policy.priority).to eq Aerospike::Priority::DEFAULT
       expect(policy.timeout).to eq 0
-      expect(policy.max_retries).to eq 2
+      expect(policy.max_retries).to eq 3
       expect(policy.sleep_between_retries).to eq 0.5
 
     end

--- a/spec/aerospike/policy/write_policy_spec.rb
+++ b/spec/aerospike/policy/write_policy_spec.rb
@@ -26,7 +26,7 @@ describe Aerospike::WritePolicy do
       expect(policy.class).to eq described_class
       expect(policy.priority).to eq Aerospike::Priority::DEFAULT
       expect(policy.timeout).to eq 0
-      expect(policy.max_retries).to eq 2
+      expect(policy.max_retries).to eq 3
       expect(policy.sleep_between_retries).to eq 0.5
       expect(policy.record_exists_action).to eq Aerospike::RecordExistsAction::UPDATE
       expect(policy.generation_policy).to eq Aerospike::GenerationPolicy::NONE


### PR DESCRIPTION
## Description

After the last round of changes, the retry mechanism was significantly more stable, but I noticed a large number of exceptions are transiting out after being wrapped by `Aerospike::Exceptions::Aerospike` and are thus not hitting the retry code path. This seems like a missed opportunity.

After playing around with this using the `break_aerospike.sh` script, I found the following changes result in almost no errors propagating up to the user code.

- I noticed that it takes some time for the cluster to recover from a failure, so retrying very frequently does not help. If the first retry fails, we sleep a bit longer each iteration to avoid hitting the cluster over and over again while it is trying to recover. This increases latency a little bit but the trade off is that the request eventually succeeds rather than fails over and over again.
- I noticed that a lot of commands will wrap the exceptions and so I modified the code to retry on almost every kind of exception except for the ones which seem to be logical "failures". This ensures that we almost always hit the retry code path.
- I found in testing that 2 retries (3 requests in total) is not sufficient for the `break_aerospike.sh` script, i.e. the recovery time is longer than the total number of requests + sleep between requests in the default configuration. My feeling is we should make the default client robust to typical failure cases, so I've basically just increased the default. We could even push it a little bit further since I think it's better to retry a few times than fail outright.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Performance improvement.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
