### PR TITLE
Use proper Ruby syntax for raising errors

### DIFF
--- a/lib/aerospike/cluster.rb
+++ b/lib/aerospike/cluster.rb
@@ -118,7 +118,7 @@ module Aerospike
         when Aerospike::Replica::RANDOM
           return random_node
         else
-          raise Aerospike::Exceptions::InvalidNode("invalid policy.replica value")
+          raise Aerospike::Exceptions::InvalidNode.new("invalid policy.replica value")
       end
     end
 
@@ -136,7 +136,7 @@ module Aerospike
         when Aerospike::Replica::RANDOM
           return random_node
         else
-          raise Aerospike::Exceptions::InvalidNode("invalid policy.replica value")
+          raise Aerospike::Exceptions::InvalidNode.new("invalid policy.replica value")
       end
     end
 
@@ -144,10 +144,10 @@ module Aerospike
     def master_node(partition)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") if !replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") if !replica_array
 
       node_array = (replica_array.get)[0]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") if !node_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") if !node_array
 
       node = (node_array.get)[partition.partition_id]
       raise Aerospike::Exceptions::InvalidNode if !node || !node.active?
@@ -159,7 +159,7 @@ module Aerospike
     def rack_node(partition, seq)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") if !replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") if !replica_array
 
       replica_array = replica_array.get
 
@@ -191,7 +191,7 @@ module Aerospike
     def master_proles_node(partition)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") if !replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") if !replica_array
 
       replica_array = replica_array.get
 
@@ -210,7 +210,7 @@ module Aerospike
     def sequence_node(partition, seq)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") if !replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") if !replica_array
 
       replica_array = replica_array.get
 


### PR DESCRIPTION
This fixes errors like `Cant get node: undefined method `InvalidNamespace' for Aerospike::Exceptions:Module` 