### PR TITLE
Only apply timeout on a socket level

### DIFF
--- a/lib/aerospike/command/command.rb
+++ b/lib/aerospike/command/command.rb
@@ -427,8 +427,6 @@ module Aerospike
     def execute
       iterations = 0
 
-      # set timeout outside the loop
-      limit = Time.now + @policy.timeout
       retries = @policy.max_retries
 
       # Execute command until successful, timed out or maximum iterations have been reached:
@@ -441,9 +439,6 @@ module Aerospike
 
         # Next iteration:
         iterations += 1
-
-        # Check for command timeout:
-        break if @policy.timeout > 0 && Time.now > limit
 
         begin
           @node = get_node
@@ -531,7 +526,7 @@ module Aerospike
       end # while
 
       # execution timeout
-      raise Aerospike::Exceptions::Timeout.new(limit, iterations)
+      raise Aerospike::Exceptions::Timeout.new(@policy.timeout, iterations)
     end
 
     protected


### PR DESCRIPTION
Clients written in other languages separate two timeouts: TCP timeout and transaction timeout.

For some weird reason, the Ruby client uses a single value for both. This doesn't make any sense whatsoever. Let's look at a typical example:

Timeout: 150ms
max_retries: 3
sleep_between_retries: 30ms

In the `limit` variable we store `now + 150ms`. We do one loop iteration, and the TCP socket times out after a `150ms`. Once we enter the loop one more time, we sleep for 30ms, and then we check: `break if @policy.timeout > 0 && Time.now > limit`. This statement always holds true when the TCP socket timed out, so we will not attempt any more retries. And we also wasted an additional 30ms sleeping without performing an additional retry.