### PR TITLE
Do not fail when scan cannot be scheduled

### DIFF
--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -542,9 +542,8 @@ module Aerospike
       statement.set_aggregate_function(package_name, function_name, function_args, false)
 
       # Use a thread per node
-      nodes.each do |node|
+      threads = nodes.map do |node|
         Thread.new do
-          Thread.current.abort_on_exception = true
           begin
             command = QueryCommand.new(node, policy, statement, nil)
             execute_command(command)
@@ -554,6 +553,9 @@ module Aerospike
           end
         end
       end
+
+      # check for value of each threads. If any thread fails, this will raise an error.
+      threads.each(&:join)
 
       ExecuteTask.new(@cluster, statement)
     end


### PR DESCRIPTION
The issue with `Thread.current.abort_on_exception = true` is that you do not know the exact moment when the exception will be raised, so you need to have a top-level `rescue` block in your whole codebase. This doesn't really play well with most applications where you want to catch such an error in a specific place, usually pretty close to the piece of code that calls the method.

We change this so that we do not abort threads on exception and we wait for all the threads to complete and check whether they all completed successfully. 



Example reproduction script:

```
# delete.lua
function delete_record(rec)
  aerospike:remove(rec)
end


# script.rb
require 'aerospike'

begin
  client = Aerospike::Client.new
  namespace = 'test'

  client.register_udf_from_file('delete.lua', 'delete.lua', Aerospike::Language::LUA)

  100.times do
    begin
      statement = Aerospike::Statement.new(namespace, 'u2')

      tenant_id = rand(2**32)

      statement.predexp = [
        Aerospike::PredExp.integer_bin('tid'),
        Aerospike::PredExp.integer_value(tenant_id),
        Aerospike::PredExp.integer_equal
      ]

      task = client.execute_udf_on_query(statement, 'delete', 'delete_record')
    rescue => e 
      puts 'inner-loop level rescue'
    end
  end

  puts 'after loop'

  sleep 1

rescue => e
  puts 'Top-level rescue'
end
```

Before:

```
after loop
#<Thread:0x00007fced989a440 /Users/kacper/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/aerospike-2.19.0/lib/aerospike/client.rb:546 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	4: from /Users/kacper/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/aerospike-2.19.0/lib/aerospike/client.rb:550:in `block (2 levels) in execute_udf_on_query'
	3: from /Users/kacper/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/aerospike-2.19.0/lib/aerospike/client.rb:901:in `execute_command'
	2: from /Users/kacper/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/aerospike-2.19.0/lib/aerospike/command/command.rb:496:in `execute'
	1: from /Users/kacper/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/aerospike-2.19.0/lib/aerospike/command/multi_command.rb:84:in `parse_result'
/Users/kacper/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/aerospike-2.19.0/lib/aerospike/query/stream_command.rb:47:in `parse_group': Operation not allowed at this time (Aerospike::Exceptions::Aerospike)
Top-level rescue
```

After:

```
... only "inner-loop level rescue"
```

