### PR TITLE
[CLIENT-3195] Fix ruby client does not return failed nodes on timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.2.0] 2024-12-18
+
+- **Fixes**
+  - [CLIENT-3195] Fix ruby client does not return failed nodes on timeout.
+
 ## [4.1.0] 2024-10-22
 
 - **New Features**

--- a/lib/aerospike/aerospike_exception.rb
+++ b/lib/aerospike/aerospike_exception.rb
@@ -21,79 +21,79 @@ require 'aerospike/result_code'
 module Aerospike
   module Exceptions
     class Aerospike < StandardError
-      attr_reader :result_code
+      attr_reader :result_code, :failed_nodes
 
-      def initialize(result_code, message = nil)
+      def initialize(result_code, message = nil, failed_nodes = nil)
         @result_code = result_code
+        @failed_nodes = failed_nodes
         message ||= ResultCode.message(result_code)
         super(message)
       end
     end
 
     class Timeout < Aerospike
-      attr_reader :timeout, :iterations, :failed_nodes, :failed_connections
+      attr_reader :timeout, :iterations, :failed_connections
 
       def initialize(timeout, iterations, failed_nodes=nil, failed_connections=nil)
         @timeout = timeout
         @iterations = iterations
-        @failed_nodes = failed_nodes
         @failed_connections = failed_connections
 
-        super(ResultCode::TIMEOUT)
+        super(ResultCode::TIMEOUT, nil, failed_nodes)
       end
     end
 
     class InvalidCredentials < Aerospike
-      def initialize(msg = nil)
-        super(ResultCode::NOT_AUTHENTICATED, msg)
+      def initialize(msg = nil, node=nil)
+        super(ResultCode::NOT_AUTHENTICATED, msg, [node])
       end
     end
 
     class Serialize < Aerospike
       def initialize(msg=nil)
-        super(ResultCode::SERIALIZE_ERROR, msg)
+        super(ResultCode::SERIALIZE_ERROR, msg, [node])
       end
     end
 
     class Parse < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::PARSE_ERROR, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::PARSE_ERROR, msg, [node])
       end
     end
 
     class Connection < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::SERVER_NOT_AVAILABLE, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::SERVER_NOT_AVAILABLE, msg, [node])
       end
     end
 
     class InvalidNode < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::INVALID_NODE_ERROR, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::INVALID_NODE_ERROR, msg, [node])
       end
     end
 
     class ScanTerminated < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::SCAN_TERMINATED, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::SCAN_TERMINATED, msg, [node])
       end
     end
 
     class QueryTerminated < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::QUERY_TERMINATED, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::QUERY_TERMINATED, msg, [node])
       end
     end
 
     class CommandRejected < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::COMMAND_REJECTED, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::COMMAND_REJECTED, msg, [node])
       end
     end
 
     class InvalidNamespace < Aerospike
-      def initialize(msg=nil)
-        super(ResultCode::INVALID_NAMESPACE, msg)
+      def initialize(msg=nil, node=nil)
+        super(ResultCode::INVALID_NAMESPACE, msg, [node])
       end
     end
   end

--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -239,7 +239,7 @@ module Aerospike
 
       response = send_info_command(policy, str_cmd, node).upcase
       return if response == "OK"
-      raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::SERVER_ERROR, "Truncate failed: #{response}")
+      raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::SERVER_ERROR, "Truncate failed: #{response}", [node])
     end
 
     #-------------------------------------------------------

--- a/lib/aerospike/cluster.rb
+++ b/lib/aerospike/cluster.rb
@@ -129,7 +129,7 @@ module Aerospike
       when Aerospike::Replica::RANDOM
           random_node
       else
-          raise Aerospike::Exceptions::InvalidNode("invalid policy.replica value")
+          raise Aerospike::Exceptions::InvalidNode.new("invalid policy.replica value")
       end
     end
 
@@ -147,7 +147,7 @@ module Aerospike
       when Aerospike::Replica::RANDOM
           random_node
       else
-          raise Aerospike::Exceptions::InvalidNode("invalid policy.replica value")
+          raise Aerospike::Exceptions::InvalidNode.new("invalid policy.replica value")
       end
     end
 
@@ -155,13 +155,13 @@ module Aerospike
     def master_node(partition)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless replica_array
 
       node_array = replica_array.get[0]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless node_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless node_array
 
       node = node_array.get[partition.partition_id]
-      raise Aerospike::Exceptions::InvalidNode if !node || !node.active?
+      raise Aerospike::Exceptions::InvalidNode.new("no active node found") if !node || !node.active?
 
       node
     end
@@ -170,7 +170,7 @@ module Aerospike
     def rack_node(partition, seq)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless replica_array
 
       replica_array = replica_array.get
 
@@ -195,14 +195,14 @@ module Aerospike
 
       return fallback if fallback
 
-      raise Aerospike::Exceptions::InvalidNode
+      raise Aerospike::Exceptions::InvalidNode.new("no active node found")
     end
 
     # Returns a node on the cluster for read operations
     def master_proles_node(partition)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless replica_array
 
       replica_array = replica_array.get
 
@@ -214,14 +214,14 @@ module Aerospike
         return node if node && node.active?
       end
 
-      raise Aerospike::Exceptions::InvalidNode
+      raise Aerospike::Exceptions::InvalidNode.new("no active node found")
     end
 
     # Returns a random node on the cluster
     def sequence_node(partition, seq)
       partition_map = partitions
       replica_array = partition_map[partition.namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless replica_array
 
       replica_array = replica_array.get
 
@@ -233,7 +233,7 @@ module Aerospike
         return node if node && node.active?
       end
 
-      raise Aerospike::Exceptions::InvalidNode
+      raise Aerospike::Exceptions::InvalidNode.new("node active node found")
     end
 
     def get_node_for_key(replica_policy, key, is_write: false)
@@ -251,10 +251,10 @@ module Aerospike
 
       partition_map = partitions
       replica_array = partition_map[namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless replica_array
 
       node_array = replica_array.get[0]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") unless node_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") unless node_array
 
 
       pid = 0
@@ -281,7 +281,7 @@ module Aerospike
 
         i = i.succ
       end
-      raise Aerospike::Exceptions::InvalidNode
+      raise Aerospike::Exceptions::InvalidNode.new("no active node found")
     end
 
     # Returns a list of all nodes in the cluster
@@ -296,7 +296,7 @@ module Aerospike
     def get_node_by_name(node_name)
       node = find_node_by_name(node_name)
 
-      raise Aerospike::Exceptions::InvalidNode unless node
+      raise Aerospike::Exceptions::InvalidNode.new("node `#{node_name}` not found") unless node
 
       node
     end

--- a/lib/aerospike/cluster/partition_parser.rb
+++ b/lib/aerospike/cluster/partition_parser.rb
@@ -42,7 +42,7 @@ module Aerospike
 
       info = info_map[REPLICAS_ALL]
       if !info || info.length == 0
-        raise Aerospike::Exceptions::Connection.new("#{REPLICAS_ALL} response for node #{@node.name} is empty")
+        raise Aerospike::Exceptions::Connection.new("#{REPLICAS_ALL} response for node #{@node.name} is empty", @node)
       end
 
       @buffer = info
@@ -112,7 +112,8 @@ module Aerospike
       if namespace.length <= 0 || namespace.length >= 32
         response = get_truncated_response
         raise Aerospike::Exceptions::Parse.new(
-          "Invalid partition namespace #{namespace}. Response=#{response}"
+          "Invalid partition namespace #{namespace}. Response=#{response}",
+          @node
         )
       end
 
@@ -133,7 +134,8 @@ module Aerospike
       if count < 0 || count > 4096
         response = get_truncated_response
         raise Aerospike::Exceptions::Parse.new(
-          "Invalid partition count #{count}. Response=#{response}"
+          "Invalid partition count #{count}. Response=#{response}",
+          @node
         )
       end
 

--- a/lib/aerospike/cluster/rack_parser.rb
+++ b/lib/aerospike/cluster/rack_parser.rb
@@ -43,7 +43,7 @@ module Aerospike
 
       info = info_map[RACK_IDS]
       if !info || info.length == 0
-        raise Aerospike::Exceptions::Connection.new("#{RACK_IDS} response for node #{@node.name} is empty")
+        raise Aerospike::Exceptions::Connection.new("#{RACK_IDS} response for node #{@node.name} is empty", @node)
       end
 
       @buffer = info
@@ -54,7 +54,7 @@ module Aerospike
         namespace = parse_name
         rack_id = parse_rack_id
 
-        @racks = {} if !@racks
+        @racks ||= {}
         @racks[namespace] = rack_id
       end
 
@@ -76,7 +76,8 @@ module Aerospike
       if namespace.length <= 0 || namespace.length >= 32
         response = get_truncated_response
         raise Aerospike::Exceptions::Parse.new(
-          "Invalid rack namespace #{namespace}. Response=#{response}"
+          "Invalid rack namespace #{namespace}. Response=#{response}",
+          @node
         )
       end
 
@@ -97,7 +98,8 @@ module Aerospike
       if rack_id < 0
         response = get_truncated_response
         raise Aerospike::Exceptions::Parse.new(
-          "Invalid rack_id #{rack_id}. Response=#{response}"
+          "Invalid rack_id #{rack_id}. Response=#{response}",
+          @node
         )
       end
 

--- a/lib/aerospike/command/batch_index_exists_command.rb
+++ b/lib/aerospike/command/batch_index_exists_command.rb
@@ -33,7 +33,7 @@ module Aerospike
       op_count = @data_buffer.read_int16(20)
 
       if op_count > 0
-        raise Aerospike::Exceptions::Parse.new('Received bins that were not requested!')
+        raise Aerospike::Exceptions::Parse.new('Received bins that were not requested!', @node)
       end
 
       skip_key(field_count)

--- a/lib/aerospike/command/command.rb
+++ b/lib/aerospike/command/command.rb
@@ -571,7 +571,7 @@ module Aerospike
       if operations
 
         unless background
-          raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::PARAMETER_ERROR)
+          raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::PARAMETER_ERROR, nil, [@node])
         end
 
         operations.each do |operation|
@@ -685,6 +685,7 @@ module Aerospike
 
     def execute
       iterations = 0
+      failed_nodes = []
 
       # set timeout outside the loop
       limit = Time.now + @policy.timeout
@@ -705,6 +706,7 @@ module Aerospike
           @node = get_node
           @conn = @node.get_connection(@policy.timeout)
         rescue => e
+          failed_nodes << @node if @node
           if @node
             # Socket connection error has occurred. Decrease health and retry.
             @node.decrease_health
@@ -724,6 +726,7 @@ module Aerospike
           begin
             write_buffer
           rescue => e
+            failed_nodes << @node if @node
             Aerospike.logger.error(e)
 
             # All runtime exceptions are considered fatal. Do not retry.
@@ -738,6 +741,7 @@ module Aerospike
           begin
             @conn.write(@data_buffer, @data_offset)
           rescue => e
+            failed_nodes << @node if @node
             # IO errors are considered temporary anomalies. Retry.
             # Close socket to flush out possible garbage. Do not put back in pool.
             @conn.close if @conn
@@ -753,6 +757,7 @@ module Aerospike
           begin
             parse_result
           rescue => e
+            failed_nodes << @node if @node
             case e
               # do not log the following exceptions
             when Aerospike::Exceptions::ScanTerminated
@@ -783,7 +788,7 @@ module Aerospike
       end # while
 
       # execution timeout
-      raise Aerospike::Exceptions::Timeout.new(limit, iterations)
+      raise Aerospike::Exceptions::Timeout.new(limit, iterations, failed_nodes)
     end
 
     protected

--- a/lib/aerospike/command/delete_command.rb
+++ b/lib/aerospike/command/delete_command.rb
@@ -59,13 +59,13 @@ module Aerospike
 
       if result_code == Aerospike::ResultCode::FILTERED_OUT
         if @policy.fail_on_filtered_out
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
         @existed = true
         return
       end
 
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
   end # class

--- a/lib/aerospike/command/exists_command.rb
+++ b/lib/aerospike/command/exists_command.rb
@@ -59,13 +59,13 @@ module Aerospike
 
       if result_code == Aerospike::ResultCode::FILTERED_OUT
         if @policy.fail_on_filtered_out
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
         @exists = true
         return
       end
 
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
   end # class

--- a/lib/aerospike/command/multi_command.rb
+++ b/lib/aerospike/command/multi_command.rb
@@ -24,7 +24,7 @@ module Aerospike
   class MultiCommand < Command #:nodoc:
 
     def initialize(node)
-      super(node)
+      super
 
       @valid = true
       @mutex = Mutex.new
@@ -69,7 +69,7 @@ module Aerospike
 
             # inflate the results
             # TODO: reuse the current buffer
-            uncompressed = Zlib::inflate(@data_buffer.buf)
+            uncompressed = Zlib.inflate(@data_buffer.buf)
             receive_size = uncompressed.size - 8
 
             @compressed_data_buffer = Buffer.new(-1, uncompressed)
@@ -83,11 +83,11 @@ module Aerospike
           end
         end
 
-        if receive_size > 0
-          status = parse_group(receive_size)
-        else
-          status = false
-        end
+        status = if receive_size > 0
+          parse_group(receive_size)
+                 else
+          false
+                 end
       end
     end
 
@@ -101,10 +101,10 @@ module Aerospike
         # The only valid server return codes are "ok", "not found" and "filtered out".
         # If other return codes are received, then abort the batch.
         if result_code != 0
-            if result_code == Aerospike::ResultCode::KEY_NOT_FOUND_ERROR || result_code == Aerospike::ResultCode::FILTERED_OUT
+            if [Aerospike::ResultCode::KEY_NOT_FOUND_ERROR, Aerospike::ResultCode::FILTERED_OUT].include?(result_code)
               # NOOP
             else
-              raise Aerospike::Exceptions::Aerospike.new(result_code)
+              raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
             end
         end
 
@@ -145,7 +145,7 @@ module Aerospike
         when Aerospike::FieldType::TABLE
           set_name = @data_buffer.read(1, size).force_encoding('utf-8')
         when Aerospike::FieldType::KEY
-          user_key = Aerospike::bytes_to_key_value(@data_buffer.read(1).ord, @data_buffer, 2, size-1)
+          user_key = Aerospike.bytes_to_key_value(@data_buffer.read(1).ord, @data_buffer, 2, size-1)
         when Aerospike::FieldType::BVAL_ARRAY
           bval = @data_buffer.read_uint64_little_endian(1)
         end
@@ -207,7 +207,7 @@ module Aerospike
         # Corrupted data streams can result in a huge length.
         # Do a sanity check here.
         if length > Aerospike::Buffer::MAX_BUFFER_SIZE
-          raise Aerospike::Exceptions::Parse.new("Invalid read_bytes length: #{length}")
+          raise Aerospike::Exceptions::Parse.new("Invalid read_bytes length: #{length}", [@node])
         end
         @data_buffer = Buffer.new(length)
       end

--- a/lib/aerospike/command/read_command.rb
+++ b/lib/aerospike/command/read_command.rb
@@ -70,7 +70,7 @@ module Aerospike
 
           # inflate the results
           # TODO: reuse the current buffer
-          uncompressed = Zlib::inflate(@data_buffer.buf)
+          uncompressed = Zlib.inflate(@data_buffer.buf)
 
           @data_buffer = Buffer.new(-1, uncompressed)
         rescue => e
@@ -126,7 +126,7 @@ module Aerospike
 
       if result_code == Aerospike::ResultCode::FILTERED_OUT
         if @policy.fail_on_filtered_out
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
         return
       end
@@ -141,19 +141,19 @@ module Aerospike
         end
       end
 
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
     def handle_udf_error(result_code)
       ret = @record.bins['FAILURE']
-      raise Aerospike::Exceptions::Aerospike.new(result_code, ret) if ret
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, ret, [@node]) if ret
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
     def parse_record(op_count, field_count, generation, expiration)
       bins = op_count > 0 ? {} : nil
       receive_offset = 0
-      single_bin_value = (!(OperatePolicy === policy) || policy.record_bin_multiplicity == RecordBinMultiplicity::SINGLE)
+      single_bin_value = !policy.is_a?(OperatePolicy) || policy.record_bin_multiplicity == RecordBinMultiplicity::SINGLE
 
       # There can be fields in the response (setname etc).
       # But for now, ignore them. Expose them to the API if needed in the future.
@@ -181,7 +181,7 @@ module Aerospike
 
         if single_bin_value || !bins.has_key?(name)
           bins[name] = value
-        elsif (prev = bins[name]).kind_of?(OpResults)
+        elsif (prev = bins[name]).is_a?(OpResults)
           prev << value
         else
           bins[name] = OpResults.new << prev << value

--- a/lib/aerospike/command/read_header_command.rb
+++ b/lib/aerospike/command/read_header_command.rb
@@ -50,7 +50,7 @@ module Aerospike
       if result_code == 0
         generation = @data_buffer.read_int32(14)
         expiration = @data_buffer.read_int32(18)
-        @record = Record.new(@node, @key, nil,  generation, expiration)
+        @record = Record.new(@node, @key, nil, generation, expiration)
         return
       end
 
@@ -62,12 +62,12 @@ module Aerospike
       if result_code == Aerospike::ResultCode::FILTERED_OUT
         @record = nil
         if @policy.fail_on_filtered_out
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
         return
       end
 
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
   end # class

--- a/lib/aerospike/command/touch_command.rb
+++ b/lib/aerospike/command/touch_command.rb
@@ -59,7 +59,7 @@ module Aerospike
 
           # inflate the results
           # TODO: reuse the current buffer
-          uncompressed = Zlib::inflate(@data_buffer.buf)
+          uncompressed = Zlib.inflate(@data_buffer.buf)
 
           @data_buffer = Buffer.new(-1, uncompressed)
         rescue => e
@@ -81,12 +81,12 @@ module Aerospike
 
       if result_code == Aerospike::ResultCode::FILTERED_OUT
         if @policy.fail_on_filtered_out
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
         return
       end
 
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
   end # class

--- a/lib/aerospike/command/write_command.rb
+++ b/lib/aerospike/command/write_command.rb
@@ -23,7 +23,6 @@ module Aerospike
   class WriteCommand < SingleCommand #:nodoc:
 
     def initialize(cluster, policy, key, bins, operation)
-
       super(cluster, key)
 
       @bins =          bins
@@ -60,12 +59,12 @@ module Aerospike
 
       if result_code == Aerospike::ResultCode::FILTERED_OUT
         if @policy.fail_on_filtered_out
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
         return
       end
 
-      raise Aerospike::Exceptions::Aerospike.new(result_code)
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
   end # class

--- a/lib/aerospike/node/verify/cluster_name.rb
+++ b/lib/aerospike/node/verify/cluster_name.rb
@@ -25,7 +25,7 @@ module Aerospike
           def call(node, info_map)
             if node.cluster_name && node.cluster_name != info_map['cluster-name']
               node.inactive!
-              raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::INVALID_NODE_ERROR, "Cluster name does not match. expected: #{node.cluster_name}, got: #{info_map['cluster-name']}")
+              raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::INVALID_NODE_ERROR, "Cluster name does not match. expected: #{node.cluster_name}, got: #{info_map['cluster-name']}", [node])
             end
           end
         end

--- a/lib/aerospike/node/verify/name.rb
+++ b/lib/aerospike/node/verify/name.rb
@@ -25,15 +25,15 @@ module Aerospike
           def call(node, info_map)
             info_name = info_map['node']
 
-            if !info_name
+            unless info_name
               node.decrease_health
-              raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::INVALID_NODE_ERROR, 'Node name is empty')
+              raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::INVALID_NODE_ERROR, 'Node name is empty', [node])
             end
 
-            if !(node.name == info_name)
+            unless node.name == info_name
               # Set node to inactive immediately.
               node.inactive!
-              raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::INVALID_NODE_ERROR, "Node name has changed. Old=#{node.name} New= #{info_name}")
+              raise Aerospike::Exceptions::Aerospike.new(Aerospike::ResultCode::INVALID_NODE_ERROR, "Node name has changed. Old=#{node.name} New= #{info_name}", [node])
             end
           end
         end

--- a/lib/aerospike/node/verify/partition_generation.rb
+++ b/lib/aerospike/node/verify/partition_generation.rb
@@ -27,7 +27,7 @@ module Aerospike
           def call(node, info_map)
             gen_string = info_map.fetch('partition-generation', nil)
 
-            raise Aerospike::Exceptions::Parse.new('partition-generation is empty') if gen_string.to_s.empty?
+            raise Aerospike::Exceptions::Parse.new('partition-generation is empty', [node]) if gen_string.to_s.empty?
 
             generation = gen_string.to_i
 

--- a/lib/aerospike/node/verify/peers_generation.rb
+++ b/lib/aerospike/node/verify/peers_generation.rb
@@ -25,7 +25,7 @@ module Aerospike
           def call(node, info_map, peers)
             gen_string = info_map.fetch('peers-generation', nil)
 
-            raise Aerospike::Exceptions::Parse.new('peers-generation is empty') if gen_string.to_s.empty?
+            raise Aerospike::Exceptions::Parse.new('peers-generation is empty', node) if gen_string.to_s.empty?
 
             generation = gen_string.to_i
 

--- a/lib/aerospike/node/verify/rebalance_generation.rb
+++ b/lib/aerospike/node/verify/rebalance_generation.rb
@@ -27,7 +27,7 @@ module Aerospike
           def call(node, info_map)
             gen_string = info_map.fetch('rebalance-generation', nil)
 
-            raise Aerospike::Exceptions::Parse.new('rebalance-generation is empty') if gen_string.to_s.empty?
+            raise Aerospike::Exceptions::Parse.new('rebalance-generation is empty', node) if gen_string.to_s.empty?
 
             generation = gen_string.to_i
 

--- a/lib/aerospike/query/partition_tracker.rb
+++ b/lib/aerospike/query/partition_tracker.rb
@@ -77,7 +77,7 @@ module Aerospike
 
       pmap = cluster.partitions
       replica_array = pmap[namespace]
-      raise Aerospike::Exceptions::InvalidNamespace("namespace not found in the partition map") if !replica_array
+      raise Aerospike::Exceptions::InvalidNamespace.new("namespace not found in the partition map") if !replica_array
 
       master = (replica_array.get)[0]
       master = master.get

--- a/lib/aerospike/query/server_command.rb
+++ b/lib/aerospike/query/server_command.rb
@@ -45,7 +45,7 @@ module Aerospike
         if result_code == Aerospike::ResultCode::KEY_NOT_FOUND_ERROR
           return false
         end
-        raise Aerospike::Exceptions::Aerospike.new(result_code)
+        raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
       end
       op_count = @data_buffer.read_int16(20)
       if op_count <= 0

--- a/lib/aerospike/query/stream_command.rb
+++ b/lib/aerospike/query/stream_command.rb
@@ -46,7 +46,7 @@ module Aerospike
           read_bytes(receive_size - @data_offset) if @data_offset < receive_size
           return nil
         else
-          raise Aerospike::Exceptions::Aerospike.new(result_code)
+          raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
         end
 
         info3 = @data_buffer.read(3).ord
@@ -72,17 +72,16 @@ module Aerospike
           next
         end
 
-        if result_code == 0
-          if @recordset.active?
-            @recordset.records.enq(parse_record(key, op_count, generation, expiration))
-          else
-            expn = @recordset.is_scan? ? SCAN_TERMINATED_EXCEPTION : QUERY_TERMINATED_EXCEPTION
-            raise expn
-          end
-
-          # UDF results do not return a key
-          @tracker&.set_last(@node_partitions, key, key.bval) if key
+        next unless result_code == 0
+        if @recordset.active?
+          @recordset.records.enq(parse_record(key, op_count, generation, expiration))
+        else
+          expn = @recordset.is_scan? ? SCAN_TERMINATED_EXCEPTION : QUERY_TERMINATED_EXCEPTION
+          raise expn
         end
+
+        # UDF results do not return a key
+        @tracker&.set_last(@node_partitions, key, key.bval) if key
       end # while
 
       true

--- a/lib/aerospike/version.rb
+++ b/lib/aerospike/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Aerospike
-  VERSION = "4.1.0"
+  VERSION = "4.2.0"
 end


### PR DESCRIPTION
merging `client_3195_no_nodes_on_timeout_exception` aka official 4.2.0 to out fork