### PR TITLE
Apply connection timeout in NodeValidator and Node#tend_connection

### DIFF
--- a/lib/aerospike/node.rb
+++ b/lib/aerospike/node.rb
@@ -120,8 +120,6 @@ module Aerospike
     def tend_connection
       if @tend_connection.nil? || @tend_connection.closed?
         @tend_connection = Cluster::CreateConnection.(cluster, host)
-        @tend_connection.timeout = cluster.connection_timeout
-        @tend_connection
       end
       @tend_connection
     end

--- a/lib/aerospike/node.rb
+++ b/lib/aerospike/node.rb
@@ -120,6 +120,7 @@ module Aerospike
     def tend_connection
       if @tend_connection.nil? || @tend_connection.closed?
         @tend_connection = Cluster::CreateConnection.(cluster, host)
+        @tend_connection.timeout = cluster.connection_timeout
       end
       @tend_connection
     end

--- a/lib/aerospike/node.rb
+++ b/lib/aerospike/node.rb
@@ -120,6 +120,8 @@ module Aerospike
     def tend_connection
       if @tend_connection.nil? || @tend_connection.closed?
         @tend_connection = Cluster::CreateConnection.(cluster, host)
+        @tend_connection.timeout = cluster.connection_timeout
+        @tend_connection
       end
       @tend_connection
     end

--- a/lib/aerospike/node_validator.rb
+++ b/lib/aerospike/node_validator.rb
@@ -20,12 +20,13 @@
 module Aerospike
   class NodeValidator # :nodoc:
 
-    attr_reader :host, :aliases, :name, :features, :cluster_name, :tls_options, :conn
+    attr_reader :host, :timeout, :aliases, :name, :features, :cluster_name, :tls_options, :conn
 
     def initialize(cluster, host, timeout, cluster_name, tls_options = {})
       @cluster = cluster
       @features = Set.new
       @host = host
+      @timeout = timeout
       @cluster_name = cluster_name
       @tls_options = tls_options
 
@@ -44,7 +45,7 @@ module Aerospike
 
       begin
         conn = Cluster::CreateConnection.(@cluster, Host.new(address, host.port, host.tls_name))
-        conn.timeout = @cluster.connection_timeout
+        conn.timeout = timeout
 
         commands = %w[node features]
         commands << address_command unless is_loopback?(address)

--- a/lib/aerospike/node_validator.rb
+++ b/lib/aerospike/node_validator.rb
@@ -44,6 +44,7 @@ module Aerospike
 
       begin
         conn = Cluster::CreateConnection.(@cluster, Host.new(address, host.port, host.tls_name))
+        conn.timeout = @cluster.connection_timeout
 
         commands = %w[node features]
         commands << address_command unless is_loopback?(address)

--- a/spec/aerospike/node_validator_spec.rb
+++ b/spec/aerospike/node_validator_spec.rb
@@ -21,6 +21,7 @@ describe Aerospike::NodeValidator do
     before do
       allow(socket).to receive(:write).and_return(nil)
       allow(socket).to receive(:read).and_return(nil)
+      allow(socket).to receive(:timeout=).and_return(nil)
       expect(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
     end
 
@@ -31,6 +32,7 @@ describe Aerospike::NodeValidator do
     let(:hosts) { [::Aerospike::Host.new('192.168.1.1', '3000')] }
 
     before do
+      allow(socket).to receive(:timeout=).and_return(nil)
       allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
 
       expect(::Aerospike::Info).to receive(:request).and_return(
@@ -49,6 +51,7 @@ describe Aerospike::NodeValidator do
     let(:hosts) { [::Aerospike::Host.new('my.lb.com', '3000')] }
 
     before do
+      allow(socket).to receive(:timeout=).and_return(nil)
       allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
       expect(Resolv).to receive(:getaddresses).and_return(['101.1.1.1', '102.1.1.1'])
 
@@ -79,6 +82,7 @@ describe Aerospike::NodeValidator do
     let(:policy) { ::Aerospike::ClientPolicy.new(tls: { enable: true }) }
 
     before do
+      allow(socket).to receive(:timeout=).and_return(nil)
       allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
       expect(Resolv).to receive(:getaddresses).and_return(['101.1.1.1', '102.1.1.1'])
 


### PR DESCRIPTION
When a node is suspended with SIGSTOP, the aerospike ruby client would hang indefinitely during node validation and cluster tending operations. This occurs because:

1. SIGSTOP doesn't close TCP connections - they remain in ESTABLISHED state
2. The suspended process can't respond to packets, but the TCP connection appears "alive"
3. Without proper timeouts, socket operations block indefinitely waiting for responses

## Root Cause Analysis

### Bug 1: NodeValidator Missing Timeout

In `NodeValidator`, the connection timeout was **never being applied** to the socket connection used for node validation:

```ruby
def initialize(cluster, host, timeout, cluster_name, tls_options = {})
  @cluster = cluster
  # timeout parameter passed but not stored as instance variable
  # ...
end

def get_hosts(address)
  # ...
  conn = Cluster::CreateConnection.(@cluster, Host.new(address, host.port, host.tls_name))
  # MISSING: No timeout set on connection!
  # Connection uses default Ruby socket behavior - blocks indefinitely

  info_map = Info.request(conn, *commands)  # This can hang forever
  # ...
end
```

### Bug 2: Node Tend Connection Missing Timeout

In `Node#tend_connection`, the timeout was **never being set** on the connection:

```ruby
def tend_connection
  if @tend_connection.nil? || @tend_connection.closed?
    @tend_connection = Cluster::CreateConnection.(cluster, host)
  end
  @tend_connection  # Returned without any timeout set
end
```

The tend connection was created but never had its timeout configured, causing it to use default blocking I/O with no timeout.

### Why This Matters for SIGSTOP

The critical flow paths affected are:

1. **During cluster initialization/seeding**:
   - `Cluster#seed_node` → Creates `NodeValidator` instances
   - `NodeValidator#get_hosts` → Creates connection without timeout
   - `Info.request` → Sends INFO commands
   - Socket read **blocks forever** on SIGSTOP'd node

2. **During cluster tending** (periodic health checks):
   - `Node::Refresh::Info` → Uses `node.tend_connection`
   - `Node::Refresh::Partitions` → Uses `node.tend_connection`
   - `Node::Refresh::Peers` → Uses `node.tend_connection`
   - `Node::Refresh::Racks` → Uses `node.tend_connection`
   - Without timeout, operations **block forever** on SIGSTOP'd node

When a node is SIGSTOP'd:

- TCP connections succeed (3-way handshake completes before suspension)
- Socket writes may succeed (data goes into kernel send buffer)
- Socket reads **block forever** - the suspended process can't send response data
- Without timeouts, there's no way to break out of the blocking read

## The Fix

### Fix 1: NodeValidator (node_validator.rb)

```ruby
def initialize(cluster, host, timeout, cluster_name, tls_options = {})
  @cluster = cluster
  @timeout = timeout  # ADD: Store timeout as instance variable
  @host = host
  # ...
end

def get_hosts(address)
  # ...
  conn = Cluster::CreateConnection.(@cluster, Host.new(address, host.port, host.tls_name))
  conn.timeout = @timeout  # ADD: Apply timeout to connection
  # ...
end
```

### Fix 2: Node Tend Connection (node.rb)

```ruby
def tend_connection
  if @tend_connection.nil? || @tend_connection.closed?
    @tend_connection = Cluster::CreateConnection.(cluster, host)
    @tend_connection.timeout = cluster.connection_timeout  # ADD: Set timeout
  end
  @tend_connection
end
```

## How the Fix Works

With connection timeouts properly set:

1. **Socket timeout propagates** through the existing socket infrastructure
2. **Existing `with_timeout` method** in `socket/base.rb` enforces the timeout:

   ```ruby
   def read_from_socket(length)
     with_timeout(@timeout) do  # @timeout now has a value from conn.timeout
       read_nonblock(length)
     end
   end
   ```

3. **IO.select with timeout** prevents indefinite blocking:

   ```ruby
   # In existing with_timeout method:
   if IO::select([self], nil, nil, timeout)  # Uses actual timeout value
     retry
   else
     fail Aerospike::Exceptions::Connection, "Socket timeout"
   end
   ```

4. **Operations fail gracefully** instead of hanging:
   - I/O times out after `connection_timeout` (default 1s)
   - Exceptions are caught by error handling
   - Node marked unhealthy or validation skipped
   - Cluster continues with other nodes