### PR TITLE
Fix tend-thread busy-loop on NodeValidator silent failure

### DIFF
--- a/lib/aerospike/cluster.rb
+++ b/lib/aerospike/cluster.rb
@@ -369,13 +369,17 @@ module Aerospike
       @tend_thread = Thread.new do
         Thread.current.abort_on_exception = false
         loop do
-
+          # Sleep is unconditional: the previous structure put `sleep` on the
+          # success path of an implicit `begin/rescue`, so a persistent error
+          # (e.g. a poisoned `@cluster_nodes` entry) busy-looped at full CPU
+          # and produced ~50 errors/sec. The rescue must not skip the backoff.
+          begin
             tend
-            sleep(@tend_interval / 1000.0)
-        rescue => e
+          rescue => e
             Aerospike.logger.error("Exception occured during tend: #{e}")
             Aerospike.logger.debug { e.backtrace.join("\n") }
-
+          end
+          sleep(@tend_interval / 1000.0)
         end
       end
     end

--- a/lib/aerospike/node/refresh/peers.rb
+++ b/lib/aerospike/node/refresh/peers.rb
@@ -43,6 +43,19 @@ module Aerospike
                 begin
                   nv = NodeValidator.new(cluster, host, cluster.connection_timeout, cluster.cluster_name, cluster.tls_options)
 
+                  # Defense-in-depth at the integration point: refuse a half-initialized
+                  # validator before it reaches `cluster.create_node`. A `nv` with empty
+                  # aliases produces a `Node` with `@host = nil` that crashes every
+                  # subsequent tend cycle. Must run before the mismatch check below — the
+                  # `name == peer.node_name && aliases.empty?` case slips past it cleanly.
+                  if nv.name.nil? || nv.aliases.empty?
+                    ::Aerospike.logger.warn(
+                      "Skipping peer #{peer.node_name} at #{host}: validator returned " \
+                      "name=#{nv.name.inspect} aliases=#{nv.aliases.size}"
+                    )
+                    next
+                  end
+
                   if nv.name != peer.node_name
                     ::Aerospike.logger.warn("Peer node #{peer.node_name} is different than actual node #{nv.name} for host #{host}");
                     # Must look for new node name in the unlikely event that node names do not agree.

--- a/lib/aerospike/node_validator.rb
+++ b/lib/aerospike/node_validator.rb
@@ -35,6 +35,15 @@ module Aerospike
       resolve(host.name).each do |address|
         @aliases += get_hosts(address)
       end
+
+      # Reject a half-initialized validator: `get_hosts` swallows connection
+      # errors silently, so without this guard a degenerate `nv` (no name, no
+      # aliases) escapes to `Cluster#create_node` and produces a `Node` with
+      # `@host = nil` that crashes on the next tend cycle.
+      if @name.nil? || @aliases.empty?
+        raise ::Aerospike::Exceptions::InvalidNode,
+              "Failed to validate node at #{host}: name=#{@name.inspect} aliases=#{@aliases.size}"
+      end
     end
 
     private
@@ -66,8 +75,8 @@ module Aerospike
         end
 
         res = aliases.map { |al| Host.new(al[:address], al[:port], host.tls_name) }
-      rescue
-        # we don't care about the actual connection error; Just need to continue
+      rescue => e
+        ::Aerospike.logger.debug { "NodeValidator: get_hosts(#{address}) failed: #{e.class}: #{e.message}" }
       ensure
         conn.close if conn
       end

--- a/spec/aerospike/cluster_spec.rb
+++ b/spec/aerospike/cluster_spec.rb
@@ -144,4 +144,37 @@ RSpec.describe Aerospike::Cluster do
       it { is_expected.to be false }
     end
   end
+
+  describe '#launch_tend_thread (Fix C: rescue path must not skip sleep)' do
+    subject(:launch!) { instance.send(:launch_tend_thread) }
+
+    let(:tend_calls) { ::Aerospike::Atomic.new(0) }
+    let(:sleep_calls) { ::Aerospike::Atomic.new(0) }
+
+    before do
+      instance.instance_variable_set(:@tend_interval, 1)
+      allow(instance).to receive(:tend) do
+        tend_calls.update { |c| c + 1 }
+        raise StandardError, 'persistent tend failure'
+      end
+      allow(instance).to receive(:sleep) do |_|
+        calls = sleep_calls.update { |c| c + 1 }
+        Thread.exit if calls >= 3
+      end
+      allow(::Aerospike.logger).to receive(:error)
+      allow(::Aerospike.logger).to receive(:debug)
+    end
+
+    after do
+      instance.instance_variable_get(:@tend_thread)&.kill
+    end
+
+    it 'sleeps once per iteration even when tend raises persistently (no busy-loop)' do
+      launch!
+      instance.instance_variable_get(:@tend_thread).join(2)
+
+      expect(sleep_calls.value).to eq(tend_calls.value)
+      expect(sleep_calls.value).to be >= 3
+    end
+  end
 end

--- a/spec/aerospike/node/refresh/peers_spec.rb
+++ b/spec/aerospike/node/refresh/peers_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Aerospike, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+RSpec.describe Aerospike::Node::Refresh::Peers do
+  subject(:call!) { described_class.call(node, peers) }
+
+  let(:node) { double('node') }
+  let(:cluster) { double('cluster') }
+  let(:tend_connection) { double('tend_connection') }
+  let(:peers) { ::Aerospike::Peers.new }
+  let(:peers_generation) { ::Aerospike::Node::Generation.new }
+  let(:peers_count) { ::Aerospike::Atomic.new(0) }
+
+  let(:peer_node_name) { 'BB92118BAB14E12' }
+  let(:peer_host) { ::Aerospike::Host.new('172.31.73.252', 3000) }
+  let(:peer) do
+    ::Aerospike::Peer.new.tap do |p|
+      p.node_name = peer_node_name
+      p.hosts = [peer_host]
+    end
+  end
+
+  let(:fetch_collection) do
+    instance_double(
+      ::Aerospike::Peers::Parse::Object,
+      generation: 1,
+      peers: [peer]
+    )
+  end
+
+  before do
+    allow(node).to receive(:cluster).and_return(cluster)
+    allow(node).to receive(:tend_connection).and_return(tend_connection)
+    allow(node).to receive(:peers_count).and_return(peers_count)
+    allow(node).to receive(:peers_generation).and_return(peers_generation)
+    allow(node).to receive(:failures).and_return(::Aerospike::Atomic.new(0))
+    allow(node).to receive(:active?).and_return(true)
+    allow(node).to receive(:name).and_return('node-self')
+
+    allow(cluster).to receive(:connection_timeout).and_return(1000)
+    allow(cluster).to receive(:cluster_name).and_return('test')
+    allow(cluster).to receive(:tls_options).and_return({})
+    allow(cluster).to receive(:find_node_by_name).and_return(nil)
+    allow(cluster).to receive(:create_node)
+
+    allow(::Aerospike::Peers::Fetch).to receive(:call).and_return(fetch_collection)
+    allow(::Aerospike::Cluster::FindNode).to receive(:call).and_return(nil)
+    allow(::Aerospike::Node::Refresh::Failed).to receive(:call)
+    allow(::Aerospike.logger).to receive(:warn)
+  end
+
+  context 'happy path: validator returns matching name and non-empty aliases' do
+    let(:new_node) { instance_double(::Aerospike::Node) }
+    let(:nv) do
+      instance_double(
+        ::Aerospike::NodeValidator,
+        name: peer_node_name,
+        aliases: [peer_host]
+      )
+    end
+
+    before do
+      allow(::Aerospike::NodeValidator).to receive(:new).and_return(nv)
+      allow(cluster).to receive(:create_node).with(nv).and_return(new_node)
+      call!
+    end
+
+    it 'creates the node and stores it in peers under the validator name' do
+      expect(cluster).to have_received(:create_node).with(nv)
+      expect(peers.nodes[peer_node_name]).to eq(new_node)
+      expect(peers_generation.changed?).to be(true)
+    end
+  end
+
+  context 'guard fires when validator name is nil' do
+    let(:nv) do
+      instance_double(::Aerospike::NodeValidator, name: nil, aliases: [])
+    end
+
+    before do
+      allow(::Aerospike::NodeValidator).to receive(:new).and_return(nv)
+      call!
+    end
+
+    it 'skips create_node, leaves peers.nodes empty, and warns' do
+      expect(cluster).not_to have_received(:create_node)
+      expect(peers.nodes).to be_empty
+      expect(::Aerospike.logger).to have_received(:warn).with(/Skipping peer.*name=nil/)
+    end
+  end
+
+  context 'guard fires when name matches but aliases is empty (path 4)' do
+    let(:nv) do
+      instance_double(::Aerospike::NodeValidator, name: peer_node_name, aliases: [])
+    end
+
+    before do
+      allow(::Aerospike::NodeValidator).to receive(:new).and_return(nv)
+      call!
+    end
+
+    it 'still skips create_node — mismatch check below cannot catch this' do
+      expect(cluster).not_to have_received(:create_node)
+      expect(peers.nodes).to be_empty
+      expect(::Aerospike.logger).to have_received(:warn).with(/aliases=0/)
+    end
+  end
+
+  context 'continues iterating peer.hosts after a guarded skip (next, not break)' do
+    let(:peer_host_b) { ::Aerospike::Host.new('172.31.73.253', 3000) }
+    let(:peer) do
+      ::Aerospike::Peer.new.tap do |p|
+        p.node_name = peer_node_name
+        p.hosts = [peer_host, peer_host_b]
+      end
+    end
+
+    let(:bad_nv) do
+      instance_double(::Aerospike::NodeValidator, name: nil, aliases: [])
+    end
+    let(:good_nv) do
+      instance_double(::Aerospike::NodeValidator, name: peer_node_name, aliases: [peer_host_b])
+    end
+    let(:new_node) { instance_double(::Aerospike::Node) }
+
+    before do
+      allow(::Aerospike::NodeValidator).to receive(:new) do |_, host, *|
+        host == peer_host ? bad_nv : good_nv
+      end
+      allow(cluster).to receive(:create_node).with(good_nv).and_return(new_node)
+      call!
+    end
+
+    it 'validates the second host and stores its node' do
+      expect(cluster).to have_received(:create_node).with(good_nv)
+      expect(peers.nodes[peer_node_name]).to eq(new_node)
+    end
+  end
+end

--- a/spec/aerospike/node_validator_spec.rb
+++ b/spec/aerospike/node_validator_spec.rb
@@ -19,10 +19,9 @@ describe Aerospike::NodeValidator do
     let(:hosts) { [::Aerospike::Host.new('127.0.0.1', '3000')] }
 
     before do
-      allow(socket).to receive(:write).and_return(nil)
-      allow(socket).to receive(:read).and_return(nil)
       allow(socket).to receive(:timeout=).and_return(nil)
-      expect(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
+      allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
+      allow(::Aerospike::Info).to receive(:request).and_return({ 'node' => 'test-node' })
     end
 
     it { expect(validator.aliases).to eq(hosts) }
@@ -35,7 +34,7 @@ describe Aerospike::NodeValidator do
       allow(socket).to receive(:timeout=).and_return(nil)
       allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
 
-      expect(::Aerospike::Info).to receive(:request).and_return(
+      allow(::Aerospike::Info).to receive(:request).and_return(
         {
           'node' => 'test-node',
           'service-clear-std' => '192.168.1.1:3000'
@@ -53,15 +52,13 @@ describe Aerospike::NodeValidator do
     before do
       allow(socket).to receive(:timeout=).and_return(nil)
       allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
-      expect(Resolv).to receive(:getaddresses).and_return(['101.1.1.1', '102.1.1.1'])
+      allow(Resolv).to receive(:getaddresses).and_return(['101.1.1.1', '102.1.1.1'])
 
-      expect(::Aerospike::Info).to receive(:request).and_return(
+      allow(::Aerospike::Info).to receive(:request).and_return(
         {
           'node' => 'test-node',
           'service-clear-std' => '101.1.1.2:3002,101.1.1.3:3003'
-        }
-      )
-      expect(::Aerospike::Info).to receive(:request).and_return(
+        },
         {
           'node' => 'test-node',
           'service-clear-std' => '102.1.1.2:3002,102.1.1.3:3003'
@@ -84,15 +81,13 @@ describe Aerospike::NodeValidator do
     before do
       allow(socket).to receive(:timeout=).and_return(nil)
       allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
-      expect(Resolv).to receive(:getaddresses).and_return(['101.1.1.1', '102.1.1.1'])
+      allow(Resolv).to receive(:getaddresses).and_return(['101.1.1.1', '102.1.1.1'])
 
-      expect(::Aerospike::Info).to receive(:request).and_return(
+      allow(::Aerospike::Info).to receive(:request).and_return(
         {
           'node' => 'test-node',
           'service-tls-std' => '101.1.1.2:3002,101.1.1.3:3003'
-        }
-      )
-      expect(::Aerospike::Info).to receive(:request).and_return(
+        },
         {
           'node' => 'test-node',
           'service-tls-std' => '102.1.1.2:3002,102.1.1.3:3003'
@@ -105,6 +100,31 @@ describe Aerospike::NodeValidator do
       expect(validator.aliases.map { |a| a.to_s }).to match_array(
         %w[101.1.1.2:3002 101.1.1.3:3003 102.1.1.2:3002 102.1.1.3:3003]
       )
+    end
+  end
+
+  describe 'post-condition: refuses half-initialized validators' do
+    let(:hosts) { [::Aerospike::Host.new('192.168.1.1', '3000')] }
+
+    before do
+      allow(socket).to receive(:timeout=).and_return(nil)
+      allow(::Aerospike::Cluster::CreateConnection).to receive(:call).and_return(socket)
+    end
+
+    context 'when get_hosts fails before assigning @name' do
+      before { allow(::Aerospike::Info).to receive(:request).and_raise(Errno::ETIMEDOUT) }
+
+      it 'raises InvalidNode' do
+        expect { validator }.to raise_error(::Aerospike::Exceptions::InvalidNode, /name=nil aliases=0/)
+      end
+    end
+
+    context 'when @name is set but aliases stay empty (path 4)' do
+      before { allow(::Aerospike::Info).to receive(:request).and_return({ 'node' => 'test-node' }) }
+
+      it 'raises InvalidNode even though @name was assigned' do
+        expect { validator }.to raise_error(::Aerospike::Exceptions::InvalidNode, /aliases=0/)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes [INF-684](https://linear.app/castleio/issue/INF-684/aerospike-ruby-client-tend-thread-busy-loops-at-50-errorssec-after).

## TL;DR

Production incident on 2026-04-24: a single Ruby pid's Aerospike tend thread busy-looped at ~50 errors/sec for ~1 hour during a peer-node flap, returning 5XX from `/v1/risk` until the pid was rolled. Three layered fixes restore self-healing.

## Root cause

A bare `rescue` in `NodeValidator#get_hosts` silently swallows connection / info-request errors. When a server hangs, the constructor returns a half-initialized `nv` (`@name = nil`, `@aliases = []`) that escapes into `Cluster#create_node` → produces a `Node` with `@host = nil` → next tend cycle calls `host.name` on nil → `NoMethodError`.

The tend loop's `sleep` sat on the success path of an implicit `begin/rescue`, so the rescue path skipped backoff and pegged CPU at ~50 iterations/sec.

### Production log signals

Two lines from pid 361 (tend thread `26450112`) captured the bug:

```
# Single occurrence — half-init nv entering @cluster_nodes (peers.rb:47):
[2026-04-24T18:08:58.190Z] WARN -- : Peer node BB92118BAB14E12 is different than actual node ␣ for host 172.31.73.252:3000

# ~50/sec for ~1 hour, 6,532 occurrences in a 2.5-min capture (cluster.rb:376):
[2026-04-24T18:08:59.394Z] ERROR -- : Exception occured during tend: undefined method 'name' for nil
```

`␣` is annotation; the raw log has a literal space — `"actual node #{nv.name}"` with `nv.name = nil` renders as a double-space gap, invisible in any rendered view. That's why the warning slipped past triage: it looked like a benign spacing artifact, not a state-corruption signal.

### Four silent-failure paths in NodeValidator

`@name` is set only inside `get_hosts`, after a successful info round-trip. Four points can leave it nil — all silent:

| # | Failure point | Resulting state |
|---|---|---|
| 1 | `Cluster::CreateConnection` raises | `name=nil, aliases=[]` |
| 2 | `Info.request` raises *(incident's path)* | `name=nil, aliases=[]` |
| 3 | `info_map['node']` is nil | `name=nil, aliases=[]` |
| 4 | `info_map[address_command].split` raises | **`name=set, aliases=[]`** |

**Path 4 is special.** `@name` is assigned *before* the `NoMethodError`, so the existing `nv.name != peer.node_name` mismatch check at `peers.rb:46` does not fire and the half-init `nv` falls through to `cluster.create_node`. This is why Fix B's guard tests both predicates and must run *before* the mismatch check.

## Fixes

### A — `lib/aerospike/node_validator.rb`

Post-condition raising `Aerospike::Exceptions::InvalidNode` when half-initialized; bare `rescue` becomes `rescue => e` with debug-level logging. Closes all four paths at the source. `InvalidNode` is already an `Aerospike::Exceptions::Aerospike` subclass, so the existing rescue at `peers.rb:60` catches it for free.

### B — `lib/aerospike/node/refresh/peers.rb`

Defense-in-depth guard before the mismatch check:

```ruby
if nv.name.nil? || nv.aliases.empty?
  ::Aerospike.logger.warn("Skipping peer #{peer.node_name} at #{host}: ...")
  next
end
```

`next` (not `break`) — other hosts of the same peer might validate fine.

### C — `lib/aerospike/cluster.rb`

Restructure `launch_tend_thread` from implicit `begin/rescue` (with `sleep` on the success path) to explicit `begin/rescue` with `sleep` outside, so backoff runs unconditionally. Without this, any future tend pathology — not just this bug — pegs CPU.

## Self-healing

With these fixes, a hung peer no longer corrupts `@cluster_nodes`. Each tend cycle re-attempts validation; the client recovers automatically once the server-side cluster prunes the bad peer. No process restart needed.

## Tests

8 new examples; each verified to fail when its corresponding fix is reverted:

| Fix | Spec | Cases | Smoking gun on revert |
|---|---|---|---|
| A | `node_validator_spec.rb` | 2 (paths 1–3 + path 4) | `expected InvalidNode but nothing raised` |
| B | `peers_spec.rb` (new) | 4 (happy + 2 guard cases + `next` vs `break`) | `peers.nodes` contained `{"BB92118BAB14E12" => nil}` |
| C | `cluster_spec.rb` | 1 | **56,698 tend calls vs 0 sleep calls in 2s** — production busy-loop reproduced |

CI's global `Support.client` tend thread caused intermittent mock conflicts in 4 pre-existing `node_validator_spec` tests; switched those to `allow(...)` (from `expect(...).to receive`) to tolerate background callers without losing assertions.

## Notes

- Bug exists in `aerospike/aerospike-client-ruby` master too — an upstream version bump would not fix it.
- Operational mitigation if it recurs before merge: roll the affected pids.
- Full incident analysis (timeline, why-only-one-pid, log evidence) in INF-684.