### PR TITLE
Fix batch send_key crash in #size (use user_key_as_value)

### DIFF
--- a/lib/aerospike/batch_delete.rb
+++ b/lib/aerospike/batch_delete.rb
@@ -39,7 +39,7 @@ module Aerospike
 
       size += @policy&.filter_exp&.size if @policy&.filter_exp
       if @policy&.send_key
-          size += @key.user_key.estimate_size + Aerospike::FIELD_HEADER_SIZE + 1
+          size += @key.user_key_as_value.estimate_size + Aerospike::FIELD_HEADER_SIZE + 1
       end
 
       size

--- a/lib/aerospike/batch_udf.rb
+++ b/lib/aerospike/batch_udf.rb
@@ -64,7 +64,7 @@ module Aerospike
      size += @policy&.filter_exp&.size if @policy&.filter_exp
 
      if @policy&.send_key
-       size += @key.user_key.estimate_size + Aerospike::FIELD_HEADER_SIZE + 1
+       size += @key.user_key_as_value.estimate_size + Aerospike::FIELD_HEADER_SIZE + 1
      end
      size += @package_name.bytesize + Aerospike::FIELD_HEADER_SIZE
      size += @function_name.bytesize + Aerospike::FIELD_HEADER_SIZE

--- a/lib/aerospike/batch_write.rb
+++ b/lib/aerospike/batch_write.rb
@@ -56,7 +56,7 @@ module Aerospike
       size += @policy&.filter_exp&.size if @policy&.filter_exp
 
       if @policy&.send_key
-        size += @key.user_key.estimate_size + Aerospike::FIELD_HEADER_SIZE + 1
+        size += @key.user_key_as_value.estimate_size + Aerospike::FIELD_HEADER_SIZE + 1
       end
 
       has_write = false


### PR DESCRIPTION
## Summary

`BatchWrite#size`, `BatchUDF#size`, and `BatchDelete#size` raised `NoMethodError: undefined method 'estimate_size' for an instance of String` whenever the batch record's policy had `send_key: true`. Since `#size` runs while estimating the wire buffer during `batch_operate`, any batch with `send_key` crashed before reaching the network.

## Root cause

The three `#size` methods called `@key.user_key.estimate_size`, but `Key#user_key` returns the *unwrapped* raw value (`@user_key.get` → `String`/`Integer`), and `#estimate_size` is defined only on `Aerospike::Value`. The single-record write path in `command.rb` already does this correctly via `user_key_as_value`.

## Fix

Replace `@key.user_key.estimate_size` with `@key.user_key_as_value.estimate_size` in:
- `lib/aerospike/batch_write.rb`
- `lib/aerospike/batch_udf.rb`
- `lib/aerospike/batch_delete.rb`

## Verification

Reproduction from the report now runs cleanly for all three classes (previously raised):

```
BatchWrite:  36    # was: crash
BatchDelete: 17    # was: crash
BatchUDF:    38    # was: crash
control:     25    # send_key omitted, unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)