### PR TITLE
Add cluster metrics listener for observability (node count, connections)

### DIFF
--- a/lib/aerospike.rb
+++ b/lib/aerospike.rb
@@ -123,6 +123,8 @@ require "aerospike/socket/tcp"
 require "aerospike/connection/authenticate"
 require "aerospike/connection/create"
 
+require "aerospike/metrics_listener"
+require "aerospike/cluster_stats"
 require "aerospike/cluster"
 require "aerospike/cluster/create_connection"
 require "aerospike/cluster/find_nodes_to_remove"

--- a/lib/aerospike/cluster.rb
+++ b/lib/aerospike/cluster.rb
@@ -48,6 +48,7 @@ module Aerospike
       @closed = Atomic.new(true)
       @mutex = Mutex.new
       @cluster_config_change_listeners = Atomic.new([])
+      @metrics_listener = policy.metrics_listener
 
       @old_node_count = 0
 
@@ -375,6 +376,7 @@ module Aerospike
           # and produced ~50 errors/sec. The rescue must not skip the backoff.
           begin
             tend
+            report_metrics
           rescue => e
             Aerospike.logger.error("Exception occured during tend: #{e}")
             Aerospike.logger.debug { e.backtrace.join("\n") }
@@ -510,6 +512,27 @@ module Aerospike
       listeners = @cluster_config_change_listeners.get
       listeners.each do |listener|
         listener.send(:cluster_config_changed, self)
+      end
+    end
+
+    # Snapshot of current cluster statistics (node count, per-node connection
+    # and failure counts). See Aerospike::ClusterStats.
+    def cluster_stats
+      ClusterStats.new(nodes)
+    end
+
+    # Report cluster metrics to the configured metrics listener, if any.
+    # Invoked once per tend interval from the tend thread. Errors raised by the
+    # listener are isolated here so a broken reporter cannot disrupt tending.
+    def report_metrics
+      listener = @metrics_listener
+      return unless listener
+
+      begin
+        listener.report(cluster_stats)
+      rescue => e
+        Aerospike.logger.error("Exception in metrics listener: #{e}")
+        Aerospike.logger.debug { e.backtrace.join("\n") }
       end
     end
 

--- a/lib/aerospike/cluster_stats.rb
+++ b/lib/aerospike/cluster_stats.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Copyright 2014-2020 Aerospike, Inc.
+#
+# Portions may be licensed to Aerospike, Inc. under one or more contributor
+# license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+module Aerospike
+  # Immutable snapshot of per-node statistics, captured during a tend cycle.
+  #
+  # @see Aerospike::ClusterStats
+  class NodeStats
+    # Node name as reported by the server, e.g. "BB9ED567E640112".
+    attr_reader :name
+
+    # Number of idle connections currently pooled for this node.
+    attr_reader :available_connections
+
+    # Number of consecutive tend failures recorded for this node.
+    attr_reader :failures
+
+    def initialize(node)
+      @name = node.name
+      @available_connections = node.connections.length
+      @failures = node.failures.value
+      @active = node.active?
+    end
+
+    # Whether the node is currently considered active by the client.
+    def active?
+      @active
+    end
+
+    def to_h
+      {
+        name: name,
+        available_connections: available_connections,
+        failures: failures,
+        active: active?
+      }
+    end
+  end
+
+  # Immutable snapshot of cluster-wide statistics, passed to a
+  # {MetricsListener#report} implementation once per tend interval.
+  #
+  # @example Reporting node count to Datadog (dogstatsd-ruby)
+  #   class DatadogReporter
+  #     def initialize(statsd); @statsd = statsd; end
+  #
+  #     def report(stats)
+  #       @statsd.gauge("aerospike.cluster.nodes", stats.node_count)
+  #       @statsd.gauge("aerospike.cluster.open_connections", stats.open_connections)
+  #       stats.nodes.each do |node|
+  #         tags = ["node:#{node.name}"]
+  #         @statsd.gauge("aerospike.node.available_connections", node.available_connections, tags: tags)
+  #         @statsd.gauge("aerospike.node.failures", node.failures, tags: tags)
+  #       end
+  #     end
+  #   end
+  #
+  #   client = Aerospike::Client.new(hosts, policy: { metrics_listener: DatadogReporter.new(Datadog::Statsd.new) })
+  class ClusterStats
+    # Array of {NodeStats}, one per node currently known to the cluster.
+    attr_reader :nodes
+
+    def initialize(nodes)
+      @nodes = nodes.map { |node| NodeStats.new(node) }
+    end
+
+    # Number of nodes currently known to the cluster.
+    def node_count
+      @nodes.size
+    end
+
+    # Names of all nodes currently known to the cluster.
+    def node_names
+      @nodes.map(&:name)
+    end
+
+    # Total number of idle pooled connections across all nodes.
+    def open_connections
+      @nodes.reduce(0) { |sum, node| sum + node.available_connections }
+    end
+
+    def to_h
+      {
+        node_count: node_count,
+        node_names: node_names,
+        open_connections: open_connections,
+        nodes: @nodes.map(&:to_h)
+      }
+    end
+  end
+end

--- a/lib/aerospike/metrics_listener.rb
+++ b/lib/aerospike/metrics_listener.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright 2014-2020 Aerospike, Inc.
+#
+# Portions may be licensed to Aerospike, Inc. under one or more contributor
+# license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+module Aerospike
+  # Contract for an object that receives periodic cluster metrics.
+  #
+  # Register an implementation via {ClientPolicy#metrics_listener} (or the
+  # +:metrics_listener+ policy option). Once registered, {#report} is invoked
+  # from the tend thread once per tend interval with a fresh {ClusterStats}
+  # snapshot — including on cycles where the node set did not change — so that
+  # gauges (e.g. node count) stay alive in the downstream metrics system.
+  #
+  # Implementing this module is optional; any object responding to
+  # +report(cluster_stats)+ is accepted (duck typing). It exists to document
+  # the contract.
+  #
+  # Exceptions raised by {#report} are caught and logged by the tend thread;
+  # they do not interrupt tending. Keep implementations fast and non-blocking,
+  # as {#report} runs inline on the tend thread.
+  module MetricsListener
+    # @param cluster_stats [Aerospike::ClusterStats] snapshot for this cycle
+    # @return [void]
+    def report(cluster_stats)
+      raise NotImplementedError, "#{self.class} must implement #report(cluster_stats)"
+    end
+  end
+end

--- a/lib/aerospike/policy/client_policy.rb
+++ b/lib/aerospike/policy/client_policy.rb
@@ -28,6 +28,7 @@ module Aerospike
     attr_accessor :tls
     attr_accessor :policies
     attr_accessor :rack_aware, :rack_id
+    attr_accessor :metrics_listener
 
     def initialize(opt={})
       # Initial host connection timeout in seconds. The timeout when opening a connection
@@ -94,6 +95,16 @@ module Aerospike
       #
       # Default: 0
       @min_connections_per_node = opt[:min_connections_per_node] || 0
+
+      # Optional listener that receives periodic cluster metrics. Any object
+      # responding to +report(cluster_stats)+ is accepted; see
+      # Aerospike::MetricsListener and Aerospike::ClusterStats. When set, its
+      # #report method is invoked from the tend thread once per tend interval
+      # with a fresh snapshot. Useful for exporting node count, connection
+      # counts, etc. to Datadog/StatsD/Prometheus.
+      #
+      # Default: nil (no metrics reporting)
+      @metrics_listener = opt[:metrics_listener]
     end
 
     def requires_authentication

--- a/spec/aerospike/cluster_spec.rb
+++ b/spec/aerospike/cluster_spec.rb
@@ -177,4 +177,42 @@ RSpec.describe Aerospike::Cluster do
       expect(sleep_calls.value).to be >= 3
     end
   end
+
+  describe '#report_metrics' do
+    subject(:report_metrics) { instance.report_metrics }
+
+    before { allow(instance).to receive(:nodes).and_return([]) }
+
+    context 'without a metrics listener' do
+      it 'does nothing' do
+        instance.instance_variable_set(:@metrics_listener, nil)
+        expect(instance).not_to receive(:cluster_stats)
+        report_metrics
+      end
+    end
+
+    context 'with a metrics listener' do
+      let(:listener) { spy('metrics_listener') }
+
+      before { instance.instance_variable_set(:@metrics_listener, listener) }
+
+      it 'reports a ClusterStats snapshot' do
+        report_metrics
+        expect(listener).to have_received(:report).with(an_instance_of(Aerospike::ClusterStats))
+      end
+
+      context 'when the listener raises' do
+        before do
+          allow(listener).to receive(:report).and_raise(StandardError, 'boom')
+          allow(::Aerospike.logger).to receive(:error)
+          allow(::Aerospike.logger).to receive(:debug)
+        end
+
+        it 'isolates the error so tending is not disrupted' do
+          expect { report_metrics }.not_to raise_error
+          expect(::Aerospike.logger).to have_received(:error).with(/metrics listener/)
+        end
+      end
+    end
+  end
 end

--- a/spec/aerospike/cluster_stats_spec.rb
+++ b/spec/aerospike/cluster_stats_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Copyright 2014-2020 Aerospike, Inc.
+#
+# Portions may be licensed to Aerospike, Inc. under one or more contributor
+# license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+RSpec.describe Aerospike::ClusterStats do
+  def fake_node(name:, connections:, failures:, active:)
+    instance_double(
+      Aerospike::Node,
+      name: name,
+      connections: instance_double(Aerospike::ConnectionPool, length: connections),
+      failures: instance_double(Aerospike::Atomic, value: failures),
+      active?: active
+    )
+  end
+
+  let(:nodes) do
+    [
+      fake_node(name: "BB1", connections: 3, failures: 0, active: true),
+      fake_node(name: "BB2", connections: 5, failures: 2, active: false)
+    ]
+  end
+
+  subject(:stats) { described_class.new(nodes) }
+
+  describe '#node_count' do
+    it 'returns the number of nodes' do
+      expect(stats.node_count).to eq(2)
+    end
+  end
+
+  describe '#node_names' do
+    it 'returns the names of all nodes' do
+      expect(stats.node_names).to eq(%w[BB1 BB2])
+    end
+  end
+
+  describe '#open_connections' do
+    it 'sums pooled connections across all nodes' do
+      expect(stats.open_connections).to eq(8)
+    end
+
+    context 'with no nodes' do
+      let(:nodes) { [] }
+
+      it 'returns zero' do
+        expect(stats.open_connections).to eq(0)
+      end
+    end
+  end
+
+  describe '#nodes' do
+    it 'exposes a NodeStats per node' do
+      expect(stats.nodes).to all(be_a(Aerospike::NodeStats))
+      expect(stats.nodes.map(&:name)).to eq(%w[BB1 BB2])
+      expect(stats.nodes.map(&:available_connections)).to eq([3, 5])
+      expect(stats.nodes.map(&:failures)).to eq([0, 2])
+      expect(stats.nodes.map(&:active?)).to eq([true, false])
+    end
+  end
+
+  describe '#to_h' do
+    it 'serializes cluster and per-node stats' do
+      expect(stats.to_h).to eq(
+        node_count: 2,
+        node_names: %w[BB1 BB2],
+        open_connections: 8,
+        nodes: [
+          { name: "BB1", available_connections: 3, failures: 0, active: true },
+          { name: "BB2", available_connections: 5, failures: 2, active: false }
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds an optional, **dependency-free** metrics hook to the client so applications can export cluster/node statistics (node count, per-node pooled connections, failures) to Datadog/StatsD/Prometheus/etc.

The client emits a fresh snapshot **once per tend interval** (default 1s) — including on cycles where the node set did not change — so downstream gauges stay alive between changes. No more scraping `"Tend finished. N nodes have joined the cluster"` log lines.

## How to integrate

1. Implement a reporter — any object responding to `report(cluster_stats)`:

```ruby
class AerospikeDatadogReporter
  def initialize(statsd)
    @statsd = statsd
  end

  # Called from the tend thread, once per tend interval.
  def report(stats)
    @statsd.gauge("aerospike.cluster.nodes", stats.node_count)
    @statsd.gauge("aerospike.cluster.open_connections", stats.open_connections)

    stats.nodes.each do |node|
      tags = ["node:#{node.name}"]
      @statsd.gauge("aerospike.node.available_connections", node.available_connections, tags: tags)
      @statsd.gauge("aerospike.node.failures", node.failures, tags: tags)
      @statsd.gauge("aerospike.node.active", node.active? ? 1 : 0, tags: tags)
    end
  end
end
```

2. Pass it via the `:metrics_listener` client policy option:

```ruby
require "datadog/statsd"

client = Aerospike::Client.new(
  hosts,
  policy: { metrics_listener: AerospikeDatadogReporter.new(Datadog::Statsd.new) }
)
```

That's it. `#report` will be called every tend interval with a `ClusterStats` snapshot.

### Snapshot API

`ClusterStats`:
- `node_count` → Integer
- `node_names` → Array<String>
- `open_connections` → Integer (sum of idle pooled connections across nodes)
- `nodes` → Array<`NodeStats`>
- `to_h` → Hash (handy for JSON logging)

`NodeStats`:
- `name`, `available_connections`, `failures`, `active?`

## Notes / tradeoffs

- **No new gem dependencies.** The app supplies the reporter; the client stays free of `dogstatsd`. This is the conventional way client libs expose observability.
- `available_connections` = idle pooled connections per node (`node.connections.length`). The pool doesn't track in-use count, so this is the closest signal without deeper changes.
- `#report` runs **inline on the tend thread** — keep it fast/non-blocking (a StatsD UDP send is fine). If heavy work is needed, push it to your own queue/thread inside the reporter.
- Listener exceptions are **caught and logged** (`"Exception in metrics listener: ..."`); a broken reporter cannot disrupt cluster tending.
- Duck-typed: implementing `Aerospike::MetricsListener` is optional and only documents the contract.

## Changes

- `lib/aerospike/cluster_stats.rb` — new `ClusterStats` / `NodeStats` value objects
- `lib/aerospike/metrics_listener.rb` — new listener contract (docs)
- `lib/aerospike/policy/client_policy.rb` — new `metrics_listener` option
- `lib/aerospike/cluster.rb` — `#report_metrics` / `#cluster_stats`, invoked each tend cycle
- `lib/aerospike.rb` — require the new files
- Specs: `spec/aerospike/cluster_stats_spec.rb` + `#report_metrics` coverage in `cluster_spec.rb`

## Testing

`bundle exec rspec spec/aerospike/cluster_stats_spec.rb spec/aerospike/cluster_spec.rb` → 30 examples, 0 failures. (The suite-level `after(:suite)` error requires a running Aerospike server and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)