### PR TITLE
Report per-record errors in batch_operate instead of aborting the batch

### DIFF
--- a/lib/aerospike/command/batch_operate_command.rb
+++ b/lib/aerospike/command/batch_operate_command.rb
@@ -125,6 +125,14 @@ module Aerospike
       mark_compressed(@policy)
     end
 
+    # Batch operate reports per-record status on each BatchRecord, so a non-OK
+    # result code for a single record must not abort the whole batch. Capture
+    # every code in parse_row instead of raising (matches respond_all_keys
+    # semantics of the Java/C/Go clients).
+    def handle_result_code(result_code)
+      # NOOP
+    end
+
     # Parse all results in the batch.  Add records to shared list.
     # If the record was not found, the bins will be nil.
     def parse_row(result_code)

--- a/lib/aerospike/command/multi_command.rb
+++ b/lib/aerospike/command/multi_command.rb
@@ -98,15 +98,7 @@ module Aerospike
         read_bytes(MSG_REMAINING_HEADER_SIZE)
         result_code = @data_buffer.read(5).ord & 0xFF
 
-        # The only valid server return codes are "ok", "not found" and "filtered out".
-        # If other return codes are received, then abort the batch.
-        if result_code != 0
-            if [Aerospike::ResultCode::KEY_NOT_FOUND_ERROR, Aerospike::ResultCode::FILTERED_OUT].include?(result_code)
-              # NOOP
-            else
-              raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
-            end
-        end
+        handle_result_code(result_code)
 
         # If cmd is the end marker of the response, do not proceed further
         info3 = @data_buffer.read(3).ord
@@ -116,6 +108,21 @@ module Aerospike
       end
 
       true
+    end
+
+    # Decide what to do with a per-record result code before the row is parsed.
+    #
+    # The only valid server return codes are "ok", "not found" and "filtered out".
+    # If other return codes are received, then abort the batch by raising.
+    #
+    # Commands that report per-record status (e.g. batch operate) override this
+    # to treat non-OK codes as data captured on each record instead of aborting
+    # the whole batch.
+    def handle_result_code(result_code)
+      return if result_code == 0
+      return if [Aerospike::ResultCode::KEY_NOT_FOUND_ERROR, Aerospike::ResultCode::FILTERED_OUT].include?(result_code)
+
+      raise Aerospike::Exceptions::Aerospike.new(result_code, nil, [@node])
     end
 
     def parse_key(field_count)

--- a/spec/aerospike/batch_operate_spec.rb
+++ b/spec/aerospike/batch_operate_spec.rb
@@ -203,6 +203,30 @@ describe Aerospike::Client do
         expect(exists).to eql false
 
       end
+
+      it 'reports per-record failures without aborting the whole batch' do
+        good_ops = [Aerospike::Operation.put(Aerospike::Bin.new("new_bin", "value"))]
+        # `add` on the pre-existing string bin "key" is a type mismatch, so the
+        # server rejects this single record with BIN_TYPE_ERROR.
+        bad_ops = [Aerospike::Operation.add(Aerospike::Bin.new("key", 1))]
+
+        records = [
+          Aerospike::BatchWrite.new(keys.first, good_ops),
+          Aerospike::BatchWrite.new(keys.last, bad_ops)
+        ]
+
+        expect { client.batch_operate(records, batch_policy) }.not_to raise_error
+
+        # The healthy record is applied and reported as OK...
+        expect(records[0].result_code).to eql Aerospike::ResultCode::OK
+        expect(records[0].record).not_to be_nil
+
+        # ...while the failing record carries its own error code.
+        expect(records[1].result_code).to eql Aerospike::ResultCode::BIN_TYPE_ERROR
+
+        # The successful write is durable and readable.
+        expect(client.get(keys.first).bins["new_bin"]).to eql "value"
+      end
     end
 
     context '#BatchDelete' do


### PR DESCRIPTION
## Problem

`Client#batch_operate` (with `BatchWrite` / `BatchUDF` / `BatchDelete` / `BatchRead` records) raised `Aerospike::Exceptions::Aerospike` and abandoned the **entire** batch as soon as one record came back with a non-OK result code (e.g. `RECORD_TOO_BIG`, `PARAMETER_ERROR`, `BIN_TYPE_ERROR`).

As a result:
1. A single bad record failed every other record in the batch — successful writes were lost / unreadable.
2. The caller couldn't do partial-failure handling: the exception carried no per-record context and `BatchRecord#result_code` was never populated for the failing (or any subsequent) record.

Per-record failures should be reported on each `BatchRecord#result_code`, leaving successful records applied/returned and the call succeeding — the point of a batch, and how the Java/C/Go clients behave (`respond_all_keys`).

## Root cause

`MultiCommand#parse_group` raised on any per-record code that wasn't OK / `KEY_NOT_FOUND_ERROR` / `FILTERED_OUT`, **before** `parse_row` recorded the code. `BatchOperateCommand#parse_row` already stores the per-record code, but never ran on the failing record because `parse_group` raised first; the exception then propagated out via `threads.each(&:join)` in `execute_batch_operate_commands`.

## Fix

- Extract the raise decision from `MultiCommand#parse_group` into an overridable `handle_result_code(result_code)`. Base behavior is unchanged (raises on unexpected codes).
- Override `handle_result_code` as a no-op in `BatchOperateCommand`, so non-OK codes fall through to `parse_row` and are captured on each `BatchRecord#result_code`. The call returns normally and the caller inspects status per record.

Scan/query (`StreamCommand`, which has its own `parse_group`) and legacy `batch_get` (`BatchIndexCommand`) keep the existing raising behavior.

## Testing

Added a spec that mixes a healthy `BatchWrite` with one that deterministically fails (`Operation.add` on a pre-existing string bin → `BIN_TYPE_ERROR`), asserting the call doesn't raise, the good record is `OK` with its record set, the bad record carries `BIN_TYPE_ERROR`, and the good write is durably readable.

Verified against a live Aerospike 7.1 server:
- New test **fails without the fix** (raises out of `batch_operate`) and **passes with it**.
- `batch_operate_spec.rb` + `batch_spec.rb`: **33 examples, 0 failures** (legacy `batch_get` raising path intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)